### PR TITLE
Fix memory leak in XML::XPath::Parser

### DIFF
--- a/lib/XML/XPath.pm
+++ b/lib/XML/XPath.pm
@@ -485,6 +485,7 @@ sub cleanup {
         my $context = $self->get_context;
         return unless $context;
         $context->dispose;
+        $self->{path_parser}->cleanup if $self->{path_parser};
     }
 }
 

--- a/lib/XML/XPath/Parser.pm
+++ b/lib/XML/XPath/Parser.pm
@@ -69,6 +69,11 @@ sub new {
     return $self;
 }
 
+sub cleanup {
+    my $self = shift;
+    $self->{cache} = {};
+}
+
 sub get_var {
     my $self = shift;
     my $var = shift;

--- a/t/cleanup.t
+++ b/t/cleanup.t
@@ -1,0 +1,27 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use constant HAS_LEAKTRACE => eval{ require Test::LeakTrace };
+use Test::More HAS_LEAKTRACE ? (tests => 1) : (skip_all => 'require Test::LeakTrace');
+use Test::LeakTrace;
+
+use XML::XPath;
+use XML::XPath::XMLParser;
+$XML::XPath::SafeMode = 1;
+
+my $data = join '', <DATA>;
+no_leaks_ok{
+    my $xp = XML::XPath->new(xml => $data);
+    my ($root) = $xp->findnodes('/');
+    $xp->cleanup;
+}
+
+__DATA__
+<Shop id="mod3838" hello="you">
+<Cart id="1" crap="crap">
+        <Item id="11" crap="crap"/>
+</Cart>
+<Cart id="2" crap="crap"/>
+</Shop>


### PR DESCRIPTION
Caused by circular reference between the parser's cache which stores nodes
and the nodes which reference the parser.
With this change $xp->cleanup will clean up the parser's cache, too.