### PR TITLE
Add the matches() XPath function.

### DIFF
--- a/lib/XML/XPath/Function.pm
+++ b/lib/XML/XPath/Function.pm
@@ -359,6 +359,37 @@ sub translate {
     return XML::XPath::Literal->new($_);
 }
 
+sub _re_flags {
+  my $opts = "";
+  my $fn = shift;
+  for my $flag (split //, shift) {
+    if ($flag =~ /[smix]/) {
+      $opts .= $flag;
+    } elsif ($flag ne 'q') {
+      die "$fn: unknown flag $flag\n";
+    }
+  }
+  return $opts eq '' ? '' : "(?$opts)";
+}
+
+sub matches {
+  my $self = shift;
+  my ($node, @params) = @_;
+  die "matches: wrong number of params\n" if @params < 2 || @params > 3;
+  my $str = $params[0]->string_value;
+  my $re = $params[1]->string_value;
+  if (@params == 3) {
+    my $flags = $params[2]->string_value;
+    my $opts = _re_flags('matches', $flags);
+    if ($flags =~ /q/) {
+      $re = $opts . quotemeta($re);
+    } else {
+      $re = $opts . $re;
+    }
+  }
+  return $str =~ /$re/ ? XML::XPath::Boolean->True : XML::XPath::Boolean->False;
+}
+
 ### BOOLEAN FUNCTIONS ###
 
 sub boolean {

--- a/t/52matches.t
+++ b/t/52matches.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+use Test::More tests => 10;
+use XML::XPath;
+
+my $xp = XML::XPath->new(ioref => *DATA);
+ok($xp);
+
+my $resultset = $xp->find('matches("foo1bar", "[[:digit:]]")');
+ok($resultset->isa('XML::XPath::Boolean'));
+is($resultset->to_literal(), 'true');
+
+$resultset = $xp->find('matches("foobar","[[:digit:]]")');
+ok($resultset->isa('XML::XPath::Boolean'));
+is($resultset->to_literal(), 'false');
+
+$resultset = $xp->find('matches("foobar", "AR", "i")');
+is($resultset->to_literal(), 'true');
+
+$resultset = $xp->find('matches("foobar", "AR")');
+is($resultset->to_literal(), 'false');
+
+eval {
+  $xp->find('matches("foobar", "x", "p")');
+};
+if ($@) {
+  ok(1);
+} else {
+  ok(0);
+}
+
+$resultset = $xp->find('matches("foo[bar", "[bar", "q")');
+is($resultset->to_literal(), 'true');
+
+$resultset = $xp->find('matches("foobar", "foo . ar", "x")');
+is($resultset->to_literal(), "true");
+
+__DATA__
+<foo/>


### PR DESCRIPTION
Note: Uses perl dialect regular expressions, not XPath dialect.

Accepts s, m, i, x and q flags in the optional third argument.