### PR TITLE
Update how examples/xpath does text encoding.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,7 @@ WriteMakefile(
     AUTHOR             => 'Matt Sergeant, AxKit.com Ltd',
     VERSION_FROM       => 'lib/XML/XPath.pm',
     ABSTRACT_FROM      => 'lib/XML/XPath.pm',
-    MIN_PERL_VERSION   => 5.006,
+    MIN_PERL_VERSION   => 5.008,
     LICENSE            => 'artistic_2',
     EXE_FILES          => [ 'examples/xpath' ],
     CONFIGURE_REQUIRES => {

--- a/examples/xpath
+++ b/examples/xpath
@@ -1,19 +1,25 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;
+use XML::XPath;
+use I18N::Langinfo qw/langinfo CODESET/;
+use Encode qw/decode/;
+use open ':std', ':locale';
 
 $| = 1;
 
-use utf8;
-use XML::XPath;
-use open ':std', ':encoding(UTF-8)';
+my $codeset = langinfo(CODESET);
+if ($codeset ne "") {
+    @ARGV = map { decode $codeset, $_ } @ARGV;
+}
 
 my $SUFFIX = "\n";
 my $PREFIX = "";
 my $quiet  = 0;
 
 my @paths;
+# TODO: Use Getopt::Long for parsing?
 PARSE: while ((@ARGV >= 1) && ($ARGV[0] =~ /^-./ )) {
     OPTIONS: {
         if ($ARGV[0] eq "-e") {
@@ -73,7 +79,8 @@ do {
     }
     else {
         $filename = 'stdin';
-        $xpath    = XML::XPath->new(ioref => \*STDIN);
+        binmode STDIN, ':raw'; # Let the XML parser decode the input
+	$xpath    = XML::XPath->new(ioref => \*STDIN);
     }
 
     my $nodes = $xpath->find(shift @curpaths);


### PR DESCRIPTION
* Get the encoding used for command line arguments from the environment. Fixes #7.

* Don't assume standard input and output are UTF-8; also get their encoding from the environment.