### PR TITLE
Support `use XML::XPath some_version;` and modernize inheritance.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,7 @@ WriteMakefile(
     AUTHOR             => 'Matt Sergeant, AxKit.com Ltd',
     VERSION_FROM       => 'lib/XML/XPath.pm',
     ABSTRACT_FROM      => 'lib/XML/XPath.pm',
-    MIN_PERL_VERSION   => 5.008,
+    MIN_PERL_VERSION   => 5.010001,
     LICENSE            => 'artistic_2',
     EXE_FILES          => [ 'examples/xpath' ],
     CONFIGURE_REQUIRES => {

--- a/lib/XML/XPath.pm
+++ b/lib/XML/XPath.pm
@@ -10,13 +10,14 @@ Version 1.47
 
 =cut
 
-use strict; use warnings;
-use vars qw($VERSION $AUTOLOAD $revision);
+use strict;
+use warnings;
+use parent qw/Exporter/;
 
-$VERSION = '1.47';
-$XML::XPath::Namespaces = 1;
-$XML::XPath::ParseParamEnt = 1;
-$XML::XPath::Debug = 0;
+our $VERSION = '1.47';
+our $Namespaces = 1;
+our $ParseParamEnt = 1;
+our $Debug = 0;
 
 use Data::Dumper;
 use XML::XPath::XMLParser;

--- a/lib/XML/XPath/Builder.pm
+++ b/lib/XML/XPath/Builder.pm
@@ -1,8 +1,9 @@
 package XML::XPath::Builder;
 
-$VERSION = '1.47';
+use strict;
+use warnings;
 
-use strict; use warnings;
+our $VERSION = '1.47';
 
 # to get array index constants
 use XML::XPath::Node;
@@ -13,10 +14,8 @@ use XML::XPath::Node::Text;
 use XML::XPath::Node::PI;
 use XML::XPath::Node::Comment;
 
-use vars qw/$xmlns_ns $xml_ns/;
-
-$xmlns_ns = "http://www.w3.org/2000/xmlns/";
-$xml_ns = "http://www.w3.org/XML/1998/namespace";
+my $xmlns_ns = "http://www.w3.org/2000/xmlns/";
+my $xml_ns = "http://www.w3.org/XML/1998/namespace";
 
 sub new {
     my $class = shift;

--- a/lib/XML/XPath/Node.pm
+++ b/lib/XML/XPath/Node.pm
@@ -1,12 +1,11 @@
 package XML::XPath::Node;
 
-$VERSION = '1.47';
-
-use strict; use warnings;
-use vars qw(@ISA @EXPORT $AUTOLOAD %EXPORT_TAGS @EXPORT_OK);
-use Exporter;
+use strict;
+use warnings;
+use parent qw/Exporter/;
 use Carp;
-@ISA = ('Exporter');
+
+our $VERSION = '1.47';
 
 sub UNKNOWN_NODE () {0;}
 sub ELEMENT_NODE () {1;}
@@ -63,7 +62,7 @@ sub node_value () { 5; }
 # sub node_prefix () { 3; }
 sub node_expanded () { 4; }
 
-@EXPORT = qw(
+our @EXPORT = qw(
     UNKNOWN_NODE
     ELEMENT_NODE
     ATTRIBUTE_NODE
@@ -84,7 +83,7 @@ sub node_expanded () { 4; }
     NAMESPACE_NODE
     );
 
-@EXPORT_OK = qw(
+our @EXPORT_OK = qw(
             node_parent
             node_pos
             node_global_pos
@@ -103,7 +102,7 @@ sub node_expanded () { 4; }
                         node_ids
         );
 
-%EXPORT_TAGS = (
+our %EXPORT_TAGS = (
     'node_keys' => [
         qw(
             node_parent
@@ -215,6 +214,7 @@ sub new {
 }
 
 sub AUTOLOAD {
+    our $AUTOLOAD;
     my $method = $AUTOLOAD;
     $method =~ s/.*:://;
 #    warn "AUTOLOAD $method!\n";
@@ -245,8 +245,7 @@ sub AUTOLOAD {
 
 package XML::XPath::NodeImpl;
 
-use vars qw/@ISA $AUTOLOAD/;
-@ISA = ('XML::XPath::Node');
+use parent qw/-norequire XML::XPath::Node/;
 
 sub new {
     die "Virtual base method";

--- a/lib/XML/XPath/Node/Attribute.pm
+++ b/lib/XML/XPath/Node/Attribute.pm
@@ -1,18 +1,17 @@
 package XML::XPath::Node::Attribute;
 
-use strict; use warnings;
-use vars qw/@ISA $VERSION/;
+use strict;
+use warnings;
+use parent qw/XML::XPath::Node/;
 
-@ISA = ('XML::XPath::Node');
-$VERSION = '1.47';
+our $VERSION = '1.47';
 
 package XML::XPath::Node::AttributeImpl;
 
-use vars qw/@ISA $VERSION/;
-@ISA = ('XML::XPath::NodeImpl', 'XML::XPath::Node::Attribute');
 use XML::XPath::Node ':node_keys';
+use parent qw/-norequire XML::XPath::NodeImpl XML::XPath::Node::Attribute/;
 
-$VERSION = '1.47';
+our $VERSION = '1.47';
 
 sub new {
 	my $class = shift;

--- a/lib/XML/XPath/Node/Comment.pm
+++ b/lib/XML/XPath/Node/Comment.pm
@@ -1,17 +1,15 @@
 package XML::XPath::Node::Comment;
 
-$VERSION = '1.47';
+use strict;
+use warnings;
+use parent qw/XML::XPath::Node/;
 
-use strict; use warnings;
-use vars qw/@ISA/;
-
-@ISA = ('XML::XPath::Node');
+our $VERSION = '1.47';
 
 package XML::XPath::Node::CommentImpl;
 
-use vars qw/@ISA/;
-@ISA = ('XML::XPath::NodeImpl', 'XML::XPath::Node::Comment');
 use XML::XPath::Node ':node_keys';
+use parent qw/-norequire XML::XPath::NodeImpl XML::XPath::Node::Comment/;
 
 sub new {
     my $class = shift;

--- a/lib/XML/XPath/Node/Element.pm
+++ b/lib/XML/XPath/Node/Element.pm
@@ -1,16 +1,14 @@
 package XML::XPath::Node::Element;
 
-$VERSION = '1.47';
+use strict;
+use warnings;
+use parent qw/XML::XPath::Node/;
 
-use strict; use warnings;
-use vars qw/@ISA/;
-
-@ISA = ('XML::XPath::Node');
+our $VERSION = '1.47';
 
 package XML::XPath::Node::ElementImpl;
 
-use vars qw/@ISA/;
-@ISA = ('XML::XPath::NodeImpl', 'XML::XPath::Node::Element');
+use parent qw/-norequire XML::XPath::NodeImpl XML::XPath::Node::Element/;
 use XML::XPath::Node ':node_keys';
 
 sub new {

--- a/lib/XML/XPath/Node/Namespace.pm
+++ b/lib/XML/XPath/Node/Namespace.pm
@@ -1,17 +1,15 @@
 package XML::XPath::Node::Namespace;
 
-$VERSION = '1.47';
+use strict;
+use warnings;
+use parent qw/XML::XPath::Node/;
 
-use strict; use warnings;
-use vars qw/@ISA/;
-
-@ISA = ('XML::XPath::Node');
+our $VERSION = '1.47';
 
 package XML::XPath::Node::NamespaceImpl;
 
-use vars qw/@ISA/;
-@ISA = ('XML::XPath::NodeImpl', 'XML::XPath::Node::Namespace');
 use XML::XPath::Node ':node_keys';
+use parent qw/-norequire XML::XPath::NodeImpl XML::XPath::Node::Namespace/;
 
 sub new {
 	my $class = shift;

--- a/lib/XML/XPath/Node/PI.pm
+++ b/lib/XML/XPath/Node/PI.pm
@@ -1,17 +1,16 @@
 package XML::XPath::Node::PI;
 
-$VERSION = '1.47';
+use strict;
+use warnings;
+use parent qw/XML::XPath::Node/;
 
-use strict; use warnings;
-use vars qw/@ISA/;
-
-@ISA = ('XML::XPath::Node');
+our $VERSION = '1.47';
 
 package XML::XPath::Node::PIImpl;
 
-use vars qw/@ISA/;
-@ISA = ('XML::XPath::NodeImpl', 'XML::XPath::Node::PI');
 use XML::XPath::Node ':node_keys';
+use parent qw/-norequire XML::XPath::NodeImpl XML::XPath::Node::PI/;
+
 
 sub new {
 	my $class = shift;

--- a/lib/XML/XPath/Node/Text.pm
+++ b/lib/XML/XPath/Node/Text.pm
@@ -1,17 +1,15 @@
 package XML::XPath::Node::Text;
 
-$VERSION = '1.47';
+use strict;
+use warnings;
+use parent qw/XML::XPath::Node/;
 
-use strict; use warnings;
-use vars qw/@ISA/;
-
-@ISA = ('XML::XPath::Node');
+our $VERSION = '1.47';
 
 package XML::XPath::Node::TextImpl;
 
-use vars qw/@ISA/;
-@ISA = ('XML::XPath::NodeImpl', 'XML::XPath::Node::Text');
 use XML::XPath::Node ':node_keys';
+use parent qw/-norequire XML::XPath::NodeImpl XML::XPath::Node::Text/;
 
 sub new {
     my $class = shift;

--- a/lib/XML/XPath/Parser.pm
+++ b/lib/XML/XPath/Parser.pm
@@ -1,19 +1,7 @@
 package XML::XPath::Parser;
 
-$VERSION = '1.47';
-
-use strict; use warnings;
-use vars qw/
-        $NCName
-        $QName
-        $NCWild
-        $QNWild
-        $NUMBER_RE
-        $NODE_TYPE
-        $AXIS_NAME
-        %AXES
-        $LITERAL/;
-
+use strict;
+use warnings;
 use Carp qw(croak);
 use XML::XPath::XMLParser;
 use XML::XPath::Step;
@@ -25,8 +13,10 @@ use XML::XPath::Literal;
 use XML::XPath::Number;
 use XML::XPath::NodeSet;
 
+our $VERSION = '1.47';
+
 # Axis name to principal node type mapping
-%AXES = (
+my %AXES = (
         'ancestor' => 'element',
         'ancestor-or-self' => 'element',
         'attribute' => 'attribute',
@@ -46,14 +36,14 @@ my $NameStartCharClassBody = "a-zA-Z_\\xC0-\\xD6\\xD8-\\xF6\\xF8-\\x{2FF}\\x{370
 my $NameCharClassBody = "${NameStartCharClassBody}\\-.0-9\\xB7\\x{300}-\\x{36F}\\x{203F}-\\x{2040}";
 my $Name = "(?:[$NameStartCharClassBody][$NameCharClassBody]*)";
 
-$NCName = $Name;
-$QName  = "$NCName(?::$NCName)?";
-$NCWild = "${NCName}:\\*";
-$QNWild = "\\*";
-$NODE_TYPE = '((text|comment|processing-instruction|node)\\(\\))';
-$AXIS_NAME = '(' . join('|', keys %AXES) . ')::';
-$NUMBER_RE = '\d+(\\.\d*)?|\\.\d+';
-$LITERAL = '\\"[^\\"]*\\"|\\\'[^\\\']*\\\'';
+my $NCName = $Name;
+my $QName  = "$NCName(?::$NCName)?";
+my $NCWild = "${NCName}:\\*";
+my $QNWild = "\\*";
+my $NODE_TYPE = '((text|comment|processing-instruction|node)\\(\\))';
+my $AXIS_NAME = '(' . join('|', keys %AXES) . ')::';
+my $NUMBER_RE = '\d+(\\.\d*)?|\\.\d+';
+my $LITERAL = '\\"[^\\"]*\\"|\\\'[^\\\']*\\\'';
 
 sub new {
     my $class = shift;

--- a/lib/XML/XPath/Step.pm
+++ b/lib/XML/XPath/Step.pm
@@ -1,10 +1,11 @@
 package XML::XPath::Step;
 
-$VERSION = '1.47';
-
 use XML::XPath::Parser;
 use XML::XPath::Node;
-use strict; use warnings;
+use strict;
+use warnings;
+
+our $VERSION = '1.47';
 
 # the beginnings of using XS for this file...
 # require DynaLoader;

--- a/lib/XML/XPath/XMLParser.pm
+++ b/lib/XML/XPath/XMLParser.pm
@@ -1,9 +1,7 @@
 package XML::XPath::XMLParser;
 
-$VERSION = '1.47';
-
-use strict; use warnings;
-
+use strict;
+use warnings;
 use XML::Parser;
 use XML::XPath::Node;
 use XML::XPath::Node::Element;
@@ -12,6 +10,8 @@ use XML::XPath::Node::Comment;
 use XML::XPath::Node::PI;
 use XML::XPath::Node::Attribute;
 use XML::XPath::Node::Namespace;
+
+our $VERSION = '1.47';
 
 my @options = qw(
         filename
@@ -23,10 +23,8 @@ my @options = qw(
 my ($_current, $_namespaces_on);
 my %IdNames;
 
-use vars qw/$xmlns_ns $xml_ns/;
-
-$xmlns_ns = "http://www.w3.org/2000/xmlns/";
-$xml_ns = "http://www.w3.org/XML/1998/namespace";
+my $xmlns_ns = "http://www.w3.org/2000/xmlns/";
+my $xml_ns = "http://www.w3.org/XML/1998/namespace";
 
 sub new {
     my $proto = shift;


### PR DESCRIPTION
Leverages Exporter's version checking even though it doesn't actually
export anything. Also replaces obsolescent `use vars` with `our` for
package variables, and manual setting of `@ISA` with `use parent`
pragmas.

Did require bumping the minimum version from 5.8 to 5.10.1 for the
parent pragma.