### PR TITLE
Properly xmlify parameters in XML::XPath::Function::as_xml

### DIFF
--- a/lib/XML/XPath/Function.pm
+++ b/lib/XML/XPath/Function.pm
@@ -36,7 +36,7 @@ sub as_xml {
     my $string = "<Function name=\"$self->{name}\"";
     my $params = "";
     foreach (@{$self->{params}}) {
-        $params .= "<Param>" . $_->as_string . "</Param>\n";
+        $params .= "<Param>" . $_->as_xml() . "</Param>\n";
     }
     if ($params) {
         $string .= ">\n$params</Function>\n";


### PR DESCRIPTION
Fixes RT issue 21954: https://rt.cpan.org/Public/Bug/Display.html?id=21954

I'm not sure what actually uses these `as_xml` methods scattered
through the modules as nothing seems to call them at a top level.
Maybe they're just there for debugging the XPath parser?